### PR TITLE
Reply-To feature

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -55,5 +55,8 @@ Navigate to Settings -> WP Single Email and change the values as you wish.
 = 1.0.0 =
 * Initial Release.
 
+= 1.1.0 =
+* Reply-To header
+
 == Upgrade Notice ==
 

--- a/public/class-wp-simple-mail-sender.php
+++ b/public/class-wp-simple-mail-sender.php
@@ -18,6 +18,7 @@
  *
  * @package WpSimpleMailSender
  * @author  Enrique Chavez <noone@tmeister.net>
+ * @author Mika Wenell <mika.wenell@uniwaves.com>
  */
 class WpSimpleMailSender {
 
@@ -61,6 +62,7 @@ class WpSimpleMailSender {
 		add_action( 'init', array( $this, 'load_plugin_textdomain' ) );
 		add_filter( 'wp_mail_from', array($this, 'change_mail_from') );
 		add_filter( 'wp_mail_from_name', array($this, 'change_mail_name') );
+        add_filter( 'wp_mail', array($this, 'change_reply') );
 	}
 
 	/**
@@ -143,6 +145,31 @@ class WpSimpleMailSender {
 		}
 
 		return $name;
+
+	}
+
+	/**
+	 * Change the mail from value
+	 *
+	 * @since 1.1.0
+	 */
+	public function change_reply($args){
+		$settings = (array) get_option( 'wses-main-options' );
+
+		if( isset( $settings['reply-to-address'] ) && strlen($settings['reply-to-address']) ){
+            // Reply-to address exists, insert it into header string
+            $reply = (isset($settings['reply-to-address']) ? $settings['reply-to-address'] : '');
+            if($reply != ''){
+                if(preg_match($replyRegex, $args['headers']) == 1){
+                    // Header contains already reply-to => replace it
+                    $args['headers'] = preg_replace($replyRegex, $reply, $args['headers']);
+                } else {
+                    // Header does not contain reply-to yet => add it to end of header
+                    $args['headers'] .= ($args['headers'] != '' ? "\r\n" : '') . 'Reply-To: ' . $reply;
+                }
+            }
+		}
+		return $args;
 
 	}
 }

--- a/wp-simple-email-sender
+++ b/wp-simple-email-sender
@@ -1,0 +1,1 @@
+wp-simple-email-sender

--- a/wp-simple-mail-sender.php
+++ b/wp-simple-mail-sender.php
@@ -15,7 +15,7 @@
  * Plugin Name:       WP Simple Mail Sender
  * Plugin URI:        https://wordpress.org/plugins/wp-simple-mail-sender
  * Description:       WP Simple Mail Sender is a very simple plugin to change the sender address and name in outgoing emails, you can use the Site Title and the Admin Email or custom values.
- * Version:           1.0.2
+ * Version:           1.1.0
  * Author:            Enrique Chavez
  * Author URI:        http://tmeister.net
  * Text Domain:       wp-simple-mail-sender-locale


### PR DESCRIPTION
Insert Reply-To header into emails. This is useful when using "send only" mail server.

Use the plugin as follows to avoid spam filters:
- Use SPF for the domain
- Use DKIM in email server (optional)
- Use server's domain name as email address of sender, e.g. your_service_name@example.com
- Use Reply-To email address which you can read and reply, e.g. your_service_name@gmail.com
